### PR TITLE
Match on lower case database-type

### DIFF
--- a/src/metabase/driver/hive_like.clj
+++ b/src/metabase/driver/hive_like.clj
@@ -1,5 +1,6 @@
 (ns metabase.driver.hive-like
   (:require [buddy.core.codecs :as codecs]
+            [clojure.string :as str]
             [honeysql.core :as hsql]
             [java-time :as t]
             [metabase.driver :as driver]
@@ -35,7 +36,7 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :hive-like
   [_ database-type]
-  (condp re-matches (name database-type)
+  (condp re-matches (str/lower-case (name database-type))
     #"boolean"          :type/Boolean
     #"tinyint"          :type/Integer
     #"smallint"         :type/Integer


### PR DESCRIPTION
Apparently some Databricks backend implementations return capital `database-types`

Converting the input `database-type` to lowercase before running the `re-matches` does the trick in getting the appropriate type for me.

It would be great if you could accept this fix for this driver. However, I do think the better solution would be to fix it in the Metabase maintained SparkSQL driver eventually. I'll open up a PR there too

Cheers!