### PR TITLE
Use lower-case-en to prevent issues with Turkish locale

### DIFF
--- a/src/metabase/driver/hive_like.clj
+++ b/src/metabase/driver/hive_like.clj
@@ -1,6 +1,5 @@
 (ns metabase.driver.hive-like
   (:require [buddy.core.codecs :as codecs]
-            [clojure.string :as str]
             [honeysql.core :as hsql]
             [java-time :as t]
             [metabase.driver :as driver]
@@ -12,6 +11,7 @@
             [metabase.driver.sql.util :as sql.u]
             [metabase.driver.sql.util.unprepare :as unprepare]
             [metabase.models.table :refer [Table]]
+            [metabase.util :as u]
             [metabase.util.date-2 :as u.date]
             [metabase.util.honeysql-extensions :as hx]
             [toucan.db :as db])
@@ -36,7 +36,7 @@
 
 (defmethod sql-jdbc.sync/database-type->base-type :hive-like
   [_ database-type]
-  (condp re-matches (str/lower-case (name database-type))
+  (condp re-matches (u/lower-case-en (name database-type))
     #"boolean"          :type/Boolean
     #"tinyint"          :type/Integer
     #"smallint"         :type/Integer


### PR DESCRIPTION
I made a PR for the SparkSQL driver as well, which got a comment about edge cases using `str/lower-case` when the locale is set to Turkish language. Therefore, they have provided a `metabase.util/lower-case-en` util function that should be used throughout the code base.