### PR TITLE
Cope with quarter interval

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Copied from https://github.com/dacort/metabase-athena-driver/blob/d7572cd99551ea998a011f8f00a1e39c1eaa59b8/Dockerfile
-ARG METABASE_VERSION=v0.45.1
+ARG METABASE_VERSION=v0.45.2
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 
@@ -43,6 +43,12 @@ RUN --mount=type=cache,target=/root/.m2/repository \
     clojure -X:deps prep
 WORKDIR /build/driver
 
+# Test stage
+FROM stg_base as stg_test
+COPY test/ ./test
+RUN clojure -X:test:deps prep
+# Some dependencies still get downloaded when the command below is run, but I'm not sure why
+CMD ["clojure", "-X:test"]
 
 # Now build the driver
 FROM stg_base as stg_build

--- a/README.md
+++ b/README.md
@@ -4,9 +4,28 @@
 
 ## Installation
 
-All you need you do is drop the driver in your `plugins/` directory. You can grab it [here](https://github.com/relferreira/metabase-sparksql-databricks-driver/releases/download/1.6.0/sparksql-databricks.metabase-driver.jar) or build it yourself:
+To build a dockerized Metabase including the Databricks driver from this repository, simply run:
 
-## Connecting
+```
+docker build -t metabase:0.45.2-db -f Dockerfile .
+```
+
+The Metabase Databricks driver gets build along the way and included in the image while building the Metabase docker image.
+
+To run the tests for this driver, run the following:
+
+```
+docker build -t metabase/databricks-test --target stg_test .
+docker run --rm --name mb-test metabase/databricks-test
+```
+
+or, if you have Clojure on your local machine, just:
+
+```
+clojure -X:test
+```
+
+# Connecting
 
 ## Parameters
 

--- a/deps.edn
+++ b/deps.edn
@@ -21,4 +21,16 @@
    :exec-fn    build-drivers.build-driver/build-driver!
    :exec-args  {:driver      :sparksql-databricks
                 :project-dir "."
-                :target-dir  "./target"}}}}
+                :target-dir  "./target"}}
+                
+ :test
+  {:extra-paths ["test"]
+   :extra-deps {metabase/metabase-core {:local/root "../metabase"}
+                metabase/build-drivers {:local/root "../metabase/bin/build-drivers"}
+                io.github.cognitect-labs/test-runner
+                {:git/tag "v0.5.0" :git/sha "b3fd0d2"}
+                expectations/expectations {:mvn/version "2.1.10"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args  {:dirs ["test"]}}}}
+

--- a/src/metabase/driver/hive_like.clj
+++ b/src/metabase/driver/hive_like.clj
@@ -135,7 +135,12 @@
 
 (defmethod sql.qp/add-interval-honeysql-form :hive-like
   [_ hsql-form amount unit]
-  (hx/+ (hx/->timestamp hsql-form) (hsql/raw (format "(INTERVAL '%d' %s)" (int amount) (name unit)))))
+  ( let [
+      interval (if (= unit :quarter) 
+        {:amount (* 3 (int amount)), :unit "month"}
+        {:amount (int amount), :unit (name unit)})
+      ]
+     (hx/+ (hx/->timestamp hsql-form) (hsql/raw (format "(INTERVAL '%d' %s)" (:amount interval) (:unit interval))))))
 
 ;; ignore the schema when producing the identifier
 (defn qualified-name-components

--- a/test/metabase/driver/hive_like_test.clj
+++ b/test/metabase/driver/hive_like_test.clj
@@ -1,10 +1,27 @@
 (ns metabase.driver.hive-like-test
   (:require [expectations :refer [expect]]
-            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]))
+            [metabase.driver.sql-jdbc.sync :as sql-jdbc.sync]
+            [metabase.driver.sql.query-processor :as sql.qp]
+            [metabase.util.honeysql-extensions :as hx]
+            [honeysql.core :as hsql]
+            ))
 
 ;; make sure the various types we use for running tests are actually mapped to the correct DB type
 (expect :type/Text     (sql-jdbc.sync/database-type->base-type :hive-like :string))
 (expect :type/Integer  (sql-jdbc.sync/database-type->base-type :hive-like :int))
+(expect :type/Integer  (sql-jdbc.sync/database-type->base-type :hive-like :INT))
 (expect :type/Date     (sql-jdbc.sync/database-type->base-type :hive-like :date))
 (expect :type/DateTime (sql-jdbc.sync/database-type->base-type :hive-like :timestamp))
 (expect :type/Float    (sql-jdbc.sync/database-type->base-type :hive-like :double))
+
+(expect 
+  (hx/+ (hx/->timestamp :%now) (hsql/raw "(INTERVAL '3' month)"))
+  (sql.qp/add-interval-honeysql-form :hive-like :%now 1 :quarter))
+
+(expect 
+  (hx/+ (hx/->timestamp :%now) (hsql/raw "(INTERVAL '6' month)"))
+  (sql.qp/add-interval-honeysql-form :hive-like :%now 2 :quarter))
+
+(expect 
+  (hx/+ (hx/->timestamp :%now) (hsql/raw "(INTERVAL '1' year)"))
+  (sql.qp/add-interval-honeysql-form :hive-like :%now 1 :year))


### PR DESCRIPTION
We noticed that the filter by `current quarter` was not working.
The reason is that the `interval x quarter` is not valid in SparkSQL. 
Quarter being 3 months, an easy fix that seems to work is rewrite (Interval '1' quarter) as (Interval '3' months)