### PR TITLE
Build driver and include in Metabase 0.46 Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@
 To build a dockerized Metabase including the Databricks driver from this repository, simply run:
 
 ```
-docker build -t metabase:0.45.2-db -f Dockerfile .
+docker build -t metabase:0.46.5-db -f Dockerfile .
 ```
 
-The Metabase Databricks driver gets build along the way and included in the image while building the Metabase docker image.
+The Metabase Databricks driver gets build and included in a final Metabase docker image.
+
+### To be fixed for >= v0.46:
 
 To run the tests for this driver, run the following:
 


### PR DESCRIPTION
Related to #18 and #17 

This updates the Dockerfile to cope with new Metabase 0.46 build processes.

This should only be merged after merging #17

I couldn't figure out how to make the unit tests work quickly and don't have more time right now. So I thought I at least provide this change so we have build process for >= 0.46

Tested it manually though (which lead to a change request in #18)