### PR TITLE
Version upgrade to 0.46.6.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #Copied from https://github.com/dacort/metabase-athena-driver/blob/d7572cd99551ea998a011f8f00a1e39c1eaa59b8/Dockerfile
-ARG METABASE_VERSION=v0.46.5
+ARG METABASE_VERSION=v0.46.6.2
 
 FROM clojure:openjdk-11-tools-deps-slim-buster AS stg_base
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To build a dockerized Metabase including the Databricks driver from this repository, simply run:
 
 ```
-docker build -t metabase:0.46.5-db -f Dockerfile .
+docker build -t metabase:0.46.6.2-db -f Dockerfile .
 ```
 
 The Metabase Databricks driver gets build and included in a final Metabase docker image.


### PR DESCRIPTION
Bumping up version to 0.46.6.2 to accommodate Google signin hotfix from https://github.com/metabase/metabase/issues/32602