### PR TITLE
update databricks jdbc driver to 2.6.36 

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -3,7 +3,7 @@
 
  :deps
  {org.clojure/core.logic {:mvn/version "1.0.0"}
-  com.databricks/databricks-jdbc {:mvn/version "2.6.32"}}
+  com.databricks/databricks-jdbc {:mvn/version "2.6.36"}}
 
  :mvn/repos
  {"athena" {:url "https://s3.amazonaws.com/maven-athena"}}


### PR DESCRIPTION
2.6.34 related to cleaning up threads:

* [SPARKJ-655] When a query fails to connect to the server, the connector does not clean up the unused threads.