### PR TITLE
Handle connection attempts to unsupported databases

### DIFF
--- a/src/metabase/driver/connection.clj
+++ b/src/metabase/driver/connection.clj
@@ -37,15 +37,16 @@
 
 (defn decorate-and-fix
   [impl]
-  (decorator
-    java.sql.Connection
-    impl
-    (getHoldability
+  (when impl
+    (decorator
+     java.sql.Connection
+     impl
+     (getHoldability
       []
       ResultSet/CLOSE_CURSORS_AT_COMMIT)
-    (setReadOnly
+     (setReadOnly
       [read-only?]
       (when (.isClosed this)
         (throw (SQLException. "Connection is closed")))
       (when read-only?
-        (throw (SQLException. "Enabling read-only mode is not supported"))))))
+        (throw (SQLException. "Enabling read-only mode is not supported")))))))

--- a/test/metabase/driver/connection_test.clj
+++ b/test/metabase/driver/connection_test.clj
@@ -1,0 +1,11 @@
+(ns metabase.driver.connection-test
+  (:require [expectations :refer [expect]]
+            [metabase.driver.connection :as connection]))
+
+(expect
+ nil
+ (connection/decorate-and-fix nil))
+
+(expect
+ some?
+ (connection/decorate-and-fix {}))


### PR DESCRIPTION
This PR is to fix #23.

As described in the [javadocs](https://docs.oracle.com/en/java/javase/17/docs/api/java.sql/java/sql/Driver.html#connect(java.lang.String,java.util.Properties)), when connect is called on a driver, it should return nil if it realizes it is the wrong kind of driver to connect to the given URL. With this change, when this happens, nil is passed on to the driver manager so that it can try other drivers.